### PR TITLE
Update opendolphin-ng.js

### DIFF
--- a/src/opendolphin-ng.js
+++ b/src/opendolphin-ng.js
@@ -101,37 +101,34 @@ angular.module('OpenDolphin').factory('dolphinNgBinder', function($timeout, dolp
 				that.withAttribute(pmId, attrName, function(attr){
 					attr.setValue(newVal);
 				});
-
-
-				// Bind value of attribute to ng-model:
-				dolphin.getAt(pmId).getAt(attrName).onValueChange(function (event) {
-					var scopeValue = propertyName ? (scope[ngModelName][propertyName]) : scope[ngModelName];
-					console.log("dolphin model changed: ", event);
-					if (event.newValue === null) {
-						//console.log("newValue is null");
-						return;
-					}
-					if (event.newValue === event.oldValue) {
-						//console.log("values are the same");
-						return;
-					}
-					if (event.newValue === scopeValue) {
-						//console.log("dolphin and ng-model are the same");
-						return;
-					}
-					$timeout(function() { // prevent nested apply problem. See https://docs.angularjs.org/error/$rootScope/inprog?p0=$apply
-						//console.log('applying change to ng');
-						if (propertyName) {
-							scope[ngModelName][propertyName] = event.newValue;
-						}
-						else {
-							scope[ngModelName] = event.newValue;
-						}
-					}, 0, true);
-				});
-
 			});
-
+			
+			// Bind value of attribute to ng-model:
+			dolphin.getAt(pmId).getAt(attrName).onValueChange(function (event) {
+				var scopeValue = propertyName ? (scope[ngModelName][propertyName]) : scope[ngModelName];
+				console.log("dolphin model changed: ", event);
+				if (event.newValue === null) {
+					//console.log("newValue is null");
+					return;
+				}
+				if (event.newValue === event.oldValue) {
+					//console.log("values are the same");
+					return;
+				}
+				if (event.newValue === scopeValue) {
+					//console.log("dolphin and ng-model are the same");
+					return;
+				}
+				$timeout(function() { // prevent nested apply problem. See https://docs.angularjs.org/error/$rootScope/inprog?p0=$apply
+					//console.log('applying change to ng');
+					if (propertyName) {
+						scope[ngModelName][propertyName] = event.newValue;
+					}
+					else {
+						scope[ngModelName] = event.newValue;
+					}
+				}, 0, true);
+			});
 
 		}
 	};


### PR DESCRIPTION
Moved `onValueChanged()`-registration on dolphin attribute out of the `scope.$watch()`-Block. This prevents multiple loitering listener registrations that otherwise happen due to repeated $watch evaluation.